### PR TITLE
convert module from a program into a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Import
     solaar = {
       url = "https://flakehub.com/f/Svenum/Solaar-Flake/*.tar.gz" # For latest stable version
       #url = "https://flakehub.com/f/Svenum/Solaar-Flake/1.1.13.tar.gz" # uncomment line for version 1.1.13
-      #url = "github:Svenum/Solaar-Flake/main; # Uncomment line for latest unstable version
+      #url = "github:Svenum/Solaar-Flake/main"; # Uncomment line for latest unstable version
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Import
       system = "x86_64-linux";
       modules = [
           solaar.nixosModules.default
-          configuration.nix
+        ./configuration.nix
       ];
     };
   }
@@ -34,7 +34,23 @@ Import
 Then enable it by putting:
 ```nix
 ...
-    programs.solaar.enable = true;
+    services.solaar.enable = true;
 ...
 ```
 in configuration.nix
+
+## Configuration
+
+The configuration is done in the `configuration.nix` file. The following options are available:
+
+```nix
+{
+  services.solaar = {
+    enable = true; # Enable the service
+    package = pkgs.solaar; # The package to use
+    window = "hide"; # Show the window on startup (show, *hide*, only [window only])
+    batteryIcons = "regular"; # Which battery icons to use (*regular*, symbolic, solaar)
+    extraArgs = ""; # Extra arguments to pass to solaar on startup
+  };
+}
+```

--- a/modules/nixos/solaar/default.nix
+++ b/modules/nixos/solaar/default.nix
@@ -2,7 +2,7 @@
 
 with lib;
 
-let cfg = config.programs.solaar;
+let cfg = config.services.solaar;
 in {
   options.services.solaar = {
     enable = mkEnableOption ''

--- a/modules/nixos/solaar/default.nix
+++ b/modules/nixos/solaar/default.nix
@@ -51,7 +51,7 @@ in {
 
     systemd.user.services.solaar = {
       description = "Solaar, the open source driver for Logitech devices";
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = [ "graphical-session.target" ];
       after = [ "dbus.service" ];
       serviceConfig = {
         Type = "simple";

--- a/modules/nixos/solaar/default.nix
+++ b/modules/nixos/solaar/default.nix
@@ -62,4 +62,8 @@ in {
       };
     };
   };
+
+	imports = [
+		(lib.mkRenamedOptionModule [ "programs" "solaar" "enable" ] [ "services" "solaar" "enable" ])
+	];
 }

--- a/modules/nixos/solaar/default.nix
+++ b/modules/nixos/solaar/default.nix
@@ -2,11 +2,9 @@
 
 with lib;
 
-let
-  cfg = config.programs.solaar;
-in
-{
-  options.programs.solaar = {
+let cfg = config.programs.solaar;
+in {
+  options.services.solaar = {
     enable = mkEnableOption ''
       Solaar, the open source driver for Logitech devices.
     '';
@@ -19,12 +17,49 @@ in
         Package witch is used for Solaar
       '';
     };
-  };
 
+    window = mkOption {
+      type = types.enum [ "show" "hide" "only" ];
+      default = "hide";
+      description = ''
+        Start with window showing / hidden / only (no tray icon)
+      '';
+    };
+
+    batteryIcons = mkOption {
+      type = types.enum [ "regular" "symbolic" "solaar" ];
+      default = "regular";
+      description = ''
+        Prefer regular battery / symbolic battery / solaar icons
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = types.str;
+      default = "";
+      example = "--restart-on-wake-up";
+      description = ''
+        Extra arguments to pass to Solaar
+      '';
+    };
+  };
 
   config = mkIf cfg.enable {
     hardware.logitech.wireless.enable = true;
     hardware.logitech.wireless.enableGraphical = mkForce false;
-    environment.systemPackages = [ pkgs.internal.solaar ];
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.user.services.solaar = {
+      description = "Solaar, the open source driver for Logitech devices";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "dbus.service" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart =
+          "${cfg.package}/bin/solaar --window ${cfg.window} --battery-icons ${cfg.batteryIcons} ${cfg.extraArgs}";
+        Restart = "on-failure";
+        RestartSec = "5";
+      };
+    };
   };
 }


### PR DESCRIPTION
Since solaar is primarily useful as a background service, I have converted the nixos module into a service.

**Changes:**
- Move config from `programs.solaar` -> `services.solaar`
- Add systemd user service `systemd.user.services.solaar` to start solaar at login
- Add new options:
  - `services.solaar.window`: start with window showing / hidden / only (no tray icon)
  - `services.solaar.batteryIcons`: prefer regular battery / symbolic battery / solaar icons
  - `services.solaar.extraArgs`: any additional arguments to pass to solaar on startup
- Add docs on options and usage to `README.md`