### PR TITLE
fix: chase nixpkgs by renaming wrapGAppsHook ident

### DIFF
--- a/packages/solaar/default.nix
+++ b/packages/solaar/default.nix
@@ -10,7 +10,7 @@
 
 , gobject-introspection
 , gtk3
-, wrapGAppsHook
+, wrapGAppsHook3
 , gdk-pixbuf
 , libappindicator
 , librsvg
@@ -33,7 +33,7 @@ python3Packages.buildPythonApplication rec{
   nativeBuildInputs = [
     gdk-pixbuf
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [


### PR DESCRIPTION
Chase changes from `nixos-unstable` revision `08dacfc`, which includes renaming identifier `wrapGAppsHook` to `wrapGAppsHook3`, resolving the build failure.

Resolves #13 